### PR TITLE
Remove conda environment dependency stubs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,15 +3,15 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - h5py=3.7.0=nompi_py310h06dffec_100
-  - ipywidgets=7.7.1=pyhd8ed1ab_0
-  - jupyterlab=3.4.3=pyhd8ed1ab_0
-  - librosa=0.9.2=pyhd8ed1ab_0
-  - matplotlib=3.5.2=py310hff52083_0
-  - numpy=1.21.6=py310h45f3432_0
-  - python=3.10.5=ha86cf86_0_cpython
-  - scipy=1.8.1=py310h7612f91_0
-  - sympy=1.10.1=py310hff52083_0
+  - h5py=3.7.0
+  - ipywidgets=7.7.1
+  - jupyterlab=3.4.3
+  - librosa=0.9.2
+  - matplotlib=3.5.2
+  - numpy=1.21.6
+  - python=3.10.5
+  - scipy=1.8.1
+  - sympy=1.10.1
   - pandas=1.5.0
   - pip
   - pip:

--- a/environment_windows.yml
+++ b/environment_windows.yml
@@ -3,15 +3,15 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - h5py=3.7.0=nompi_py310h06dffec_100
-  - ipywidgets=7.7.1=pyhd8ed1ab_0
-  - jupyterlab=3.4.3=pyhd8ed1ab_0
-  - librosa=0.9.2=pyhd8ed1ab_0
-  - matplotlib=3.5.2=py310hff52083_0
-  - numpy=1.21.6=py310h45f3432_0
-  - python=3.10.5=ha86cf86_0_cpython
-  - scipy=1.8.1=py310h7612f91_0
-  - sympy=1.10.1=py310hff52083_0
+  - h5py=3.7.0
+  - ipywidgets=7.7.1
+  - jupyterlab=3.4.3
+  - librosa=0.9.2
+  - matplotlib=3.5.2
+  - numpy=1.21.6
+  - python=3.10.5
+  - scipy=1.8.1
+  - sympy=1.10.1
   - pandas=1.5.0
   - pip
   - pip:


### PR DESCRIPTION
Fixes `ResolvePackageNotFound`. I only tested on Windows but I don't think you need the last part of the dependencies.

```
quant-comp-ls-mod-ica22> Conda env create -f environment_windows.yml
Collecting package metadata (repodata.json): done
Solving environment: failed
ResolvePackageNotFound: 
  - h5py==3.7.0=nompi_py310h06dffec_100
  - scipy==1.8.1=py310h7612f91_0
  - python==3.10.5=ha86cf86_0_cpython
  - numpy==1.21.6=py310h45f3432_0
  - sympy==1.10.1=py310hff52083_0
  - matplotlib==3.5.2=py310hff52083_0
```